### PR TITLE
load Application env for sftp_adapter and ssh_adpter in runtime instead of compile time

### DIFF
--- a/lib/sftp_client/operation_util.ex
+++ b/lib/sftp_client/operation_util.ex
@@ -7,20 +7,17 @@ defmodule SFTPClient.OperationUtil do
   alias SFTPClient.InvalidOptionError
   alias SFTPClient.OperationError
 
-  @sftp_adapter Application.get_env(:sftp_client, :sftp_adapter, :ssh_sftp)
-  @ssh_adapter Application.get_env(:sftp_client, :ssh_adapter, :ssh)
-
   @doc """
   Gets the configured SFTP adapter. Defaults to the Erlang `:ssh_sftp` module.
   """
   @spec sftp_adapter() :: module
-  def sftp_adapter, do: @sftp_adapter
+  def sftp_adapter, do: Application.get_env(:sftp_client, :sftp_adapter, :ssh_sftp)
 
   @doc """
   Gets the configured SSH adapter. Defaults to the Erlang `:ssh` module.
   """
   @spec ssh_adapter() :: module
-  def ssh_adapter, do: @ssh_adapter
+  def ssh_adapter, do: Application.get_env(:sftp_client, :ssh_adapter, :ssh)
 
   @doc """
   Converts the result of a non-bang function so that the result is returned or


### PR DESCRIPTION
Hello guys. Thank you so much for this great library. I think it’s the best among all sftp library in elixir.
I made a small change in this PR which is using private function to load application env for adapter instead of module attributes. Since module attribute is compiled and it can’t be changed in runtime, while it’s very simplistic and elegant but it provides less flexibility.

For example, if I compile the deps only, and later compile the main application that using it. I won’t able to change the adapter module even if I set  `config :sftp_client,  sftp_adapter: SFTPClient.Adapter.SFTP.Mock` in the main application config.

Another problem is it will not able to change it in runtime which might be useful in running test that we might want to use a different adapter on the different test unit. The only downside of not using module attribute for it might be just a tiny bit performance hit of calling a nif function to get it from application environment every time the function get called