### PR TITLE
Allow key_cb configuration

### DIFF
--- a/lib/sftp_client/config.ex
+++ b/lib/sftp_client/config.ex
@@ -48,7 +48,7 @@ defmodule SFTPClient.Config do
   @spec new(t | Keyword.t() | %{optional(atom) => any}) :: t
   def new(config_or_opts)
   def new(%__MODULE__{} = config), do: config |> set_key_cb()
-  def new(opts), do: struct!(__MODULE__, opts) |> set_key_cb()
+  def new(opts), do: __MODULE__ |> struct!(opts) |> set_key_cb()
 
   defp set_key_cb(%__MODULE__{key_cb: nil} = config) do
     %__MODULE__{

--- a/lib/sftp_client/config.ex
+++ b/lib/sftp_client/config.ex
@@ -18,7 +18,8 @@ defmodule SFTPClient.Config do
     {:inet, :inet},
     :sftp_vsn,
     {:connect_timeout, 5000},
-    {:operation_timeout, :infinity}
+    {:operation_timeout, :infinity},
+    :key_cb
   ]
 
   @type t :: %__MODULE__{
@@ -36,7 +37,8 @@ defmodule SFTPClient.Config do
           inet: :inet | :inet6,
           sftp_vsn: integer,
           connect_timeout: timeout,
-          operation_timeout: timeout
+          operation_timeout: timeout,
+          key_cb: tuple
         }
 
   @doc """
@@ -45,6 +47,18 @@ defmodule SFTPClient.Config do
   """
   @spec new(t | Keyword.t() | %{optional(atom) => any}) :: t
   def new(config_or_opts)
-  def new(%__MODULE__{} = config), do: config
-  def new(opts), do: struct!(__MODULE__, opts)
+  def new(%__MODULE__{} = config), do: config |> set_key_cb()
+  def new(opts), do: struct!(__MODULE__, opts) |> set_key_cb()
+
+  defp set_key_cb(%__MODULE__{key_cb: nil} = config) do
+    %__MODULE__{
+      config
+      | key_cb:
+          {SFTPClient.KeyProvider,
+           private_key_path: config.private_key_path,
+           private_key_pass_phrase: config.private_key_pass_phrase}
+    }
+  end
+
+  defp set_key_cb(config), do: config
 end

--- a/lib/sftp_client/operations/connect.ex
+++ b/lib/sftp_client/operations/connect.ex
@@ -37,6 +37,9 @@ defmodule SFTPClient.Operations.Connect do
     5000 ms), can be set to `:infinity` to disable timeout.
   * `:operation_timeout` - The operation timeout in milliseconds (defaults to
     5000 ms), can be set to `:infinity` to disable timeout.
+  * `:key_cb` - A 2-item tuple containing:
+     - A module that implements `:ssh_client_key_api` behaviour.
+     - `:ssh_client_key_api` behaviour opts.
   """
   @spec connect(Config.t() | Keyword.t() | %{optional(atom) => any}) ::
           {:ok, Conn.t()} | {:error, term}

--- a/lib/sftp_client/operations/connect.ex
+++ b/lib/sftp_client/operations/connect.ex
@@ -141,10 +141,6 @@ defmodule SFTPClient.Operations.Connect do
 
   defp get_opts(config) do
     Enum.sort([
-      {:key_cb,
-       {KeyProvider,
-        private_key_path: config.private_key_path,
-        private_key_pass_phrase: config.private_key_pass_phrase}},
       {:quiet_mode, true},
       {:silently_accept_hosts, true},
       {:user_interaction, false}
@@ -164,7 +160,8 @@ defmodule SFTPClient.Operations.Connect do
       :connect_timeout,
       :dsa_pass_phrase,
       :rsa_pass_phrase,
-      :ecdsa_pass_phrase
+      :ecdsa_pass_phrase,
+      :key_cb
     ])
     |> Enum.reduce([], fn
       {_key, nil}, opts ->

--- a/test/sftp_client/config_test.exs
+++ b/test/sftp_client/config_test.exs
@@ -20,7 +20,10 @@ defmodule SFTPClient.ConfigTest do
          connect_timeout: 1000,
          dsa_pass_phrase: "dsa_t3$t",
          rsa_pass_phrase: "rsa_t3$t",
-         ecdsa_pass_phrase: "ecdsa_t3$t"
+         ecdsa_pass_phrase: "ecdsa_t3$t",
+         key_cb:
+           {RandomProvider,
+            private_key_path: :path, private_key_pass_phrase: :phrase}
        }}
     end
 
@@ -41,6 +44,25 @@ defmodule SFTPClient.ConfigTest do
       assert config.dsa_pass_phrase == nil
       assert config.rsa_pass_phrase == nil
       assert config.ecdsa_pass_phrase == nil
+    end
+
+    test "ensures key_cb is set to the expected default" do
+      private_key_path = "whatever_path"
+      private_key_pass_phrase = "whatever_pass_phrase"
+
+      config =
+        Config.new(
+          private_key_path: private_key_path,
+          private_key_pass_phrase: private_key_pass_phrase
+        )
+
+      assert config.private_key_path == private_key_path
+      assert config.private_key_pass_phrase == private_key_pass_phrase
+
+      assert config.key_cb ==
+               {SFTPClient.KeyProvider,
+                private_key_path: config.private_key_path,
+                private_key_pass_phrase: config.private_key_pass_phrase}
     end
 
     test "build config with keyword list", %{data: data} do

--- a/test/sftp_client/operations/connect_test.exs
+++ b/test/sftp_client/operations/connect_test.exs
@@ -24,7 +24,11 @@ defmodule SFTPClient.Operations.ConnectTest do
     inet: :inet,
     sftp_vsn: 2,
     connect_timeout: 1000,
-    operation_timeout: 500
+    operation_timeout: 500,
+    key_cb:
+      {SFTPClient.KeyProvider,
+       private_key_path: "test/fixtures/ssh_keys/id_rsa",
+       private_key_pass_phrase: "t3$t"}
   }
 
   setup :verify_on_exit!


### PR DESCRIPTION
# Proposal

This PR aims to make `key_cb` option configurable.

# Motivation

This has been done so we could store our private key in an environment variable, avoiding the hassle of setting up a file storage just for this file.