### PR TITLE
[Fix] Handle other message types from erl ssh_sftp

### DIFF
--- a/lib/sftp_client/operation_util.ex
+++ b/lib/sftp_client/operation_util.ex
@@ -52,8 +52,8 @@ defmodule SFTPClient.OperationUtil do
     %InvalidOptionError{key: key, value: load_opt_value(value), reason: reason}
   end
 
-  def handle_error({:error, reason}) do
-    %ConnError{message: to_string(reason)}
+  def handle_error(reason) when is_tuple(reason) do
+    %ConnError{message: inspect(reason)}
   end
 
   def handle_error(reason) when is_atom(reason) do

--- a/lib/sftp_client/operation_util.ex
+++ b/lib/sftp_client/operation_util.ex
@@ -52,6 +52,10 @@ defmodule SFTPClient.OperationUtil do
     %InvalidOptionError{key: key, value: load_opt_value(value), reason: reason}
   end
 
+  def handle_error({:error, reason}) do
+    %ConnError{message: to_string(reason)}
+  end
+
   def handle_error(reason) when is_atom(reason) do
     %OperationError{reason: reason}
   end

--- a/test/sftp_client/operation_util_test.exs
+++ b/test/sftp_client/operation_util_test.exs
@@ -70,5 +70,13 @@ defmodule SFTPClient.OperationUtilTest do
                message: to_string(message)
              }
     end
+
+    test "tuple conn error" do
+      error = {:error, :closed}
+
+      assert OperationUtil.handle_error(error) == %ConnError{
+               message: to_string(:closed)
+             }
+    end
   end
 end


### PR DESCRIPTION
It seems in certain situations Erlang client answers with an error tuple
like {:error, :closed} and not with a single message
See docs for start_channel return type at  http://erlang.org/doc/man/ssh_sftp.html#type-reason (tuple)
Note that this patch does not take into account tuples not starting with
:error, like the one in the example ({exit_status,1})