### PR TITLE
Adding read_dir/1 and read_dir!/1 to SFTPClient

### DIFF
--- a/lib/sftp_client.ex
+++ b/lib/sftp_client.ex
@@ -181,6 +181,8 @@ defmodule SFTPClient do
   defdelegate open_dir!(conn, path, fun), to: Operations.OpenDir
   defdelegate open_dir(conn, path), to: Operations.OpenDir
   defdelegate open_dir(conn, path, fun), to: Operations.OpenDir
+  defdelegate read_dir(handle), to: Operations.ReadDir
+  defdelegate read_dir!(handle), to: Operations.ReadDir
   defdelegate open_file!(conn, path, modes), to: Operations.OpenFile
   defdelegate open_file!(conn, path, modes, fun), to: Operations.OpenFile
   defdelegate open_file(conn, path, modes), to: Operations.OpenFile

--- a/lib/sftp_client/operation_util.ex
+++ b/lib/sftp_client/operation_util.ex
@@ -32,6 +32,8 @@ defmodule SFTPClient.OperationUtil do
 
   def may_bang!(:ok), do: :ok
 
+  def may_bang!(:eof), do: :eof
+
   def may_bang!({:ok, result}), do: result
 
   def may_bang!({:error, %{__exception__: _} = error}), do: raise(error)

--- a/lib/sftp_client/operations/read_dir.ex
+++ b/lib/sftp_client/operations/read_dir.ex
@@ -20,6 +20,7 @@ defmodule SFTPClient.Operations.ReadDir do
     |> case do
       {:ok, entries} -> {:ok, process_entries(entries, handle.path)}
       {:error, error} -> {:error, handle_error(error)}
+      :eof -> :eof
     end
   end
 

--- a/test/sftp_client/operation_util_test.exs
+++ b/test/sftp_client/operation_util_test.exs
@@ -11,6 +11,10 @@ defmodule SFTPClient.OperationUtilTest do
       assert OperationUtil.may_bang!(:ok) == :ok
     end
 
+    test "return eof on eof" do
+      assert OperationUtil.may_bang!(:eof) == :eof
+    end
+
     test "return result on ok tuple" do
       result = "result double"
 

--- a/test/sftp_client/operations/read_dir_test.exs
+++ b/test/sftp_client/operations/read_dir_test.exs
@@ -58,6 +58,16 @@ defmodule SFTPClient.Operations.ReadDirTest do
       assert ReadDir.read_dir(@handle) == {:ok, decoded_entries}
     end
 
+    test "success eof" do
+      expect(SFTPMock, :readdir, fn :channel_pid_stub,
+                                    :handle_id_stub,
+                                    :infinity ->
+        :eof
+      end)
+
+      assert ReadDir.read_dir(@handle) == :eof
+    end
+
     test "error" do
       reason = :enoent
 


### PR DESCRIPTION
Also fixing that `ssh_sftp`'s `readdir/2` can return `:eof`,
see how `ssh_sftp.erl` uses it internally for `do_list_dir/4` here:

https://github.com/erlang/otp/blob/ae8c2abc757558b9836f5373da34d5f0c245a040/lib/ssh/src/ssh_sftp.erl#L757-L767

Not sure if it's better to add `:eof` as a valid return value to `may_bang!/1`
or if it's nicer to wrap it in `{:ok, :eof}` in `ReadDir`.

The comitted version is closest to the erlang one, which I think makes the most sense.