### PR TITLE
Support `modify_algorithms` as an SSH option.

### DIFF
--- a/lib/sftp_client/config.ex
+++ b/lib/sftp_client/config.ex
@@ -19,7 +19,8 @@ defmodule SFTPClient.Config do
     :sftp_vsn,
     {:connect_timeout, 5000},
     {:operation_timeout, :infinity},
-    :key_cb
+    :key_cb,
+    :modify_algorithms
   ]
 
   @type t :: %__MODULE__{
@@ -38,7 +39,8 @@ defmodule SFTPClient.Config do
           sftp_vsn: integer,
           connect_timeout: timeout,
           operation_timeout: timeout,
-          key_cb: {module, term}
+          key_cb: {module, term},
+          modify_algorithms: nil | Keyword.t()
         }
 
   @doc """

--- a/lib/sftp_client/operations/connect.ex
+++ b/lib/sftp_client/operations/connect.ex
@@ -163,7 +163,8 @@ defmodule SFTPClient.Operations.Connect do
       :dsa_pass_phrase,
       :rsa_pass_phrase,
       :ecdsa_pass_phrase,
-      :key_cb
+      :key_cb,
+      :modify_algorithms
     ])
     |> Enum.reduce([], fn
       {_key, nil}, opts ->

--- a/test/sftp_client/config_test.exs
+++ b/test/sftp_client/config_test.exs
@@ -23,7 +23,10 @@ defmodule SFTPClient.ConfigTest do
          ecdsa_pass_phrase: "ecdsa_t3$t",
          key_cb:
            {RandomProvider,
-            private_key_path: :path, private_key_pass_phrase: :phrase}
+            private_key_path: :path, private_key_pass_phrase: :phrase},
+         modify_algorithms: [
+           {:append, [{:kex, [:"diffie-hellman-group1-sha1"]}]}
+         ]
        }}
     end
 
@@ -44,6 +47,7 @@ defmodule SFTPClient.ConfigTest do
       assert config.dsa_pass_phrase == nil
       assert config.rsa_pass_phrase == nil
       assert config.ecdsa_pass_phrase == nil
+      assert config.modify_algorithms == nil
     end
 
     test "ensures key_cb is set to the expected default" do


### PR DESCRIPTION
### Changes
* Support `modify_algorithms` as an SSH option.
  * This allows KEX algorithms that are not supported by default in OTP to be used. OTP 23 removed some deprecated algorithms (e.g. diffie-hellman-group1-sha1), but connecting to legacy servers may requrie support to be re-enabled.

### Issues
* This partially resolves https://github.com/tlux/sftp_client/issues/19