### PR TITLE
Openssh v1 private key support

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.13.2
-erlang 24.2
+elixir 1.13.4-otp-24
+erlang 24.3.4.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,20 @@ script:
 
 matrix:
   include:
-    - elixir: '1.8.1'
-      otp_release: '21.3.8'
-    - elixir: '1.9.0'
-      otp_release: '22.0.1'
-    - elixir: '1.10.4'
-      otp_release: '22.0.1'
-    - elixir: '1.10.4'
-      otp_release: '23.0.1'
-    - elixir: '1.11.4'
-      otp_release: '23.2.5'
-    - elixir: '1.12.0'
-      otp_release: '24.0.1'
+    - elixir: "1.8.1"
+      otp_release: "21.3.8"
+    - elixir: "1.9.0"
+      otp_release: "22.0.1"
+    - elixir: "1.10.4"
+      otp_release: "22.0.1"
+    - elixir: "1.10.4"
+      otp_release: "23.0.1"
+    - elixir: "1.11.4"
+      otp_release: "23.2.5"
+    - elixir: "1.12.0"
+      otp_release: "24.0.1"
+    - elixir: "1.14.0"
+      otp_release: "25.1.0"
 
 cache:
   directories:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,20 @@
-sftp_password:
-  image: atmoz/sftp
-  volumes:
-      - ./test/sftp_files:/home/foo/files
-  ports:
-      - "2222:22"
-  command: foo:s3cret:1001
+version: "3.9"
 
-sftp_keys:
-  image: atmoz/sftp
-  volumes:
-      - ./test/sftp_files:/home/foo/files
-      - ./test/fixtures/ssh_keys/id_rsa.pub:/home/foo/.ssh/keys/id_rsa.pub:ro
-      - ./test/fixtures/ssh_keys/id_ed25519.pub:/home/foo/.ssh/keys/id_ed25519.pub:ro
-  ports:
-      - "2223:22"
-  command: foo::1001
+services:
+  sftp_password:
+    image: atmoz/sftp
+    volumes:
+        - ./test/sftp_files:/home/foo/files
+    ports:
+        - "2222:22"
+    command: foo:s3cret:1001
+
+  sftp_keys:
+    image: atmoz/sftp
+    volumes:
+        - ./test/sftp_files:/home/foo/files
+        - ./test/fixtures/ssh_keys/id_rsa.pub:/home/foo/.ssh/keys/id_rsa.pub:ro
+        - ./test/fixtures/ssh_keys/id_ed25519.pub:/home/foo/.ssh/keys/id_ed25519.pub:ro
+    ports:
+        - "2223:22"
+    command: foo::1001

--- a/test/sftp_client/key_auth_integration_test.exs
+++ b/test/sftp_client/key_auth_integration_test.exs
@@ -1,0 +1,34 @@
+defmodule SFTPClient.KeyAuthIntegrationTest do
+  use SFTPClient.IntegrationCase
+
+  alias SFTPClient.Config
+
+  @tag :tmp_dir
+  test "upload with private key", %{tmp_dir: tmp_dir} do
+    config =
+      Config.new(%{
+        host: "localhost",
+        port: 2223,
+        user: "foo",
+        private_key_path: "test/fixtures/ssh_keys/id_rsa",
+        user_dir: tmp_dir
+      })
+
+    store_dir = "files/#{:os.system_time(:millisecond)}"
+
+    assert {:ok, conn} = SFTPClient.connect(config)
+    assert :ok = SFTPClient.make_dir(conn, store_dir)
+
+    assert {:ok, _} =
+             SFTPClient.upload_file(
+               conn,
+               "test/fixtures/lorem_ipsum.txt",
+               "#{store_dir}/lorem-ipsum.txt"
+             )
+
+    assert {:ok, ["lorem-ipsum.txt"]} = SFTPClient.list_dir(conn, store_dir)
+    assert :ok = SFTPClient.delete_file(conn, "#{store_dir}/lorem-ipsum.txt")
+    assert :ok = SFTPClient.delete_dir(conn, store_dir)
+    assert :ok = SFTPClient.disconnect(conn)
+  end
+end


### PR DESCRIPTION
This PR adds support for openssh v1 private keys.

The method used relies on `https://github.com/erlang/otp/blob/master/lib/ssh/src/ssh_file.erl#L833` which can be used directly within `KeyProvider` module.

The solution has been tested through a new integration test that uses the existing docker-compose configured containers, I don't know if those tests are automatically executed anywhere, otherwise they could be a good candidate to be added while working on https://github.com/tlux/sftp_client/issues/27

It also adds Elixir 1.14 and otp 25.1.0 to the CI matrix

Thanks for any feedback :)