### PR TITLE
Added preferred_algorithms and packet_size config options

### DIFF
--- a/lib/sftp_client/config.ex
+++ b/lib/sftp_client/config.ex
@@ -20,7 +20,9 @@ defmodule SFTPClient.Config do
     {:connect_timeout, 5000},
     {:operation_timeout, :infinity},
     :key_cb,
-    :modify_algorithms
+    :modify_algorithms,
+    :preferred_algorithms,
+    :packet_size
   ]
 
   @type t :: %__MODULE__{
@@ -40,7 +42,9 @@ defmodule SFTPClient.Config do
           connect_timeout: timeout,
           operation_timeout: timeout,
           key_cb: nil | {module, term},
-          modify_algorithms: nil | Keyword.t()
+          modify_algorithms: nil | Keyword.t(),
+          preferred_algorithms: nil | Keyword.t(),
+          packet_size: non_neg_integer
         }
 
   @doc """

--- a/lib/sftp_client/operations/connect.ex
+++ b/lib/sftp_client/operations/connect.ex
@@ -43,6 +43,8 @@ defmodule SFTPClient.Operations.Connect do
     implementation to support non-OTP default encryption algorithms. To
     re-enable `diffie-hellman-group1-sha1`, removed in OTP 23, pass:
     `modify_algorithms: [append: [kex: [:"diffie-hellman-group1-sha1"]]]`
+  * `:preferred_algorithms` - Replace the default set of algorithms
+  * `:packet_size` - Modify the tcp layer packet size
   """
   @spec connect(Config.t() | Keyword.t() | %{optional(atom) => any}) ::
           {:ok, Conn.t()} | {:error, term}
@@ -168,7 +170,9 @@ defmodule SFTPClient.Operations.Connect do
       :rsa_pass_phrase,
       :ecdsa_pass_phrase,
       :key_cb,
-      :modify_algorithms
+      :modify_algorithms,
+      :preferred_algorithms,
+      :packet_size
     ])
     |> Enum.reduce([], fn
       {_key, nil}, opts ->

--- a/test/sftp_client/config_test.exs
+++ b/test/sftp_client/config_test.exs
@@ -26,7 +26,9 @@ defmodule SFTPClient.ConfigTest do
             private_key_path: :path, private_key_pass_phrase: :phrase},
          modify_algorithms: [
            {:append, [{:kex, [:"diffie-hellman-group1-sha1"]}]}
-         ]
+         ],
+         preferred_algorithms: [{:kex, [:"diffie-hellman-group1-sha1"]}],
+         packet_size: 32_000
        }}
     end
 
@@ -48,6 +50,8 @@ defmodule SFTPClient.ConfigTest do
       assert config.rsa_pass_phrase == nil
       assert config.ecdsa_pass_phrase == nil
       assert config.modify_algorithms == nil
+      assert config.preferred_algorithms == nil
+      assert config.packet_size == nil
     end
 
     test "ensures key_cb is set to the expected default" do


### PR DESCRIPTION
Adding two more config options that get passed to the underlying erlang ssh connect: `preferred_algorithms` and `packet_size`